### PR TITLE
fix: swallowing uv sync failures hides broken environments

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -19,6 +19,6 @@
 
 set -e
 
-uv sync --locked --extra=${CUDA_NAME} || true
+uv sync --locked --extra=${CUDA_NAME}
 
 exec "$@"


### PR DESCRIPTION
This PR fixes a script issue in `bin/entrypoint.sh`: swallowing uv sync failures hides broken environments.

## Changes
- `bin/entrypoint.sh`: swallowing uv sync failures hides broken environments.

## Details
```diff
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -1,1 +1,1 @@
-uv sync --locked --extra=${CUDA_NAME} || true
+uv sync --locked --extra=${CUDA_NAME}
```

## Tests
- `tests/test_entrypoint.sh`

```diff
--- /dev/null
+++ tests/test_entrypoint.sh
@@ -0,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regression test: entrypoint must fail when uv sync fails.
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+mkdir -p "$tmp/bin"
+cat > "$tmp/bin/uv" <<'EOF'
+#!/usr/bin/env bash
+echo "uv: simulated failure" >&2
+exit 1
+EOF
+chmod +x "$tmp/bin/uv"
+
+cp bin/entrypoint.sh "$tmp/entrypoint.sh"
+export PATH="$tmp/bin:$PATH"
+
+if "$tmp/entrypoint.sh" echo "should not run"; then
+  echo "FAIL: entrypoint continued despite uv sync failure"
+  exit 1
+else
+  echo "PASS: entrypoint failed on uv sync failure"
+fi
```